### PR TITLE
Corrected thread usage

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,6 +1,6 @@
 [
     {
-        "caption": "cdnjs: Import Script",
+        "caption": "Cdnjs: Import Script",
         "command": "cdnjs"
     }
 ]

--- a/cdnjs.py
+++ b/cdnjs.py
@@ -7,23 +7,12 @@ import json
 
 class CdnjsCommand(sublime_plugin.TextCommand):
     def run(self, edit):
-        self.edit = edit
-        self.packages = CdnjsApiCall(30).run()
-        package_list = map(lambda x: [x['name'], x['description']], self.packages)
-        self.view.window().show_quick_panel(package_list, self.insert_tag)
-
-    def insert_tag(self, index):
-        if index == -1:
-            return
-        pkg = self.packages[index]
-        cdn_url = "http://cdnjs.cloudflare.com/ajax/libs/"
-        path = "%s/%s/%s" % (pkg['name'], pkg['version'], pkg['filename'])
-        tag = "<script src=\"%s%s\"></script>" % (cdn_url, path)
-        self.view.insert(self.edit, self.view.sel()[0].begin(), tag)
-
+        CdnjsApiCall(self.view, edit, 30).start()
 
 class CdnjsApiCall(threading.Thread):
-    def __init__(self, timeout):
+    def __init__(self, view, edit, timeout):
+        self.view = view
+        self.edit = edit
         self.timeout = timeout
         threading.Thread.__init__(self)
 
@@ -34,12 +23,29 @@ class CdnjsApiCall(threading.Thread):
             )
             http_file = urllib2.urlopen(request, timeout=self.timeout)
             result = http_file.read()
-            return json.loads(result)['packages'][:-1]
-
+            
+            self.packages = json.loads(result)['packages'][:-1]
+            package_list = [[x['name'], x['description']] for x in self.packages]
+            
+            def show_quick_panel():
+                if not package_list:
+                    sublime.error_message(('%s: There are no packages available'))
+                    return
+                self.view.window().show_quick_panel(package_list, self.insert_tag)
+            
+            # show_quick_panel must execute on the main thread. This timeout will make it so
+            sublime.set_timeout(show_quick_panel, 10)
         except (urllib2.HTTPError) as (e):
-            err = '%s: HTTP error %s contacting API' % (__name__, str(e.code))
+            sublime.error_message('%s: HTTP error %s contacting API' % (__name__, str(e.code)))
         except (urllib2.URLError) as (e):
-            err = '%s: URL error %s contacting API' % (__name__, str(e.reason))
+            sublime.error_message('%s: URL error %s contacting API' % (__name__, str(e.reason)))
 
-        sublime.error_message(err)
-        return False
+        
+    def insert_tag(self, index):
+        if index == -1:
+            return
+        pkg = self.packages[index]
+        cdn_url = "http://cdnjs.cloudflare.com/ajax/libs/"
+        path = "%s/%s/%s" % (pkg['name'], pkg['version'], pkg['filename'])
+        tag = "<script src=\"%s%s\"></script>" % (cdn_url, path)
+        self.view.insert(self.edit, self.view.sel()[0].begin(), tag)


### PR DESCRIPTION
Yo!

Thanks for making this. I didn't know cdnjs existed until browsing through the Package Control sublime packages and finding this package. Awesome, awesome, awesome.

This change modifies two things:
1. Corrects the usage of the thread so that the api call does not block the UI
2. Use a capital in Cdnjs in the default sublime commands so it fits with the convention of everything else

Thanks!
