### PR TITLE
New option to get only the URL of the resource (proper codebase)

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -2,5 +2,9 @@
     {
         "caption": "Cdnjs: Import Script",
         "command": "cdnjs"
+    },
+    {
+        "caption": "Cdnjs: Import URL only",
+        "command": "cdnjs_url"
     }
 ]


### PR DESCRIPTION
**NOTE**: this a re-do of [this pull request](https://github.com/dafrancis/Sublime-Text--cdnjs/pull/10), now for the latest version of the codebase.

Sometimes you just need the URL of the resource (either the JS or the CSS) to place it somwhere in your code (like in require.js's paths configuration). I added a new "Import URL only" option that only prints the URL of the resource, without any wrapping tag.
