### PR TITLE
Fix version selection bug

### DIFF
--- a/cdnjs.py
+++ b/cdnjs.py
@@ -145,7 +145,7 @@ class CdnjsTagBuilder(sublime_plugin.TextCommand):
     def get_path(self):
         path = self.PATH_FORMAT % {
             "name": self.package["name"],
-            "version": self.package["version"],
+            "version": self.asset["version"],
             "filename": self.file
         }
 


### PR DESCRIPTION
As mentioned in another issue, the version selector always chooses the latest version. This should fix that.
