### PR TITLE
Improved performance by adding a search api in addition to the current way of fetching files

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,0 +1,3 @@
+[
+    { "command": "cdnjs_search" }
+]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -10,5 +10,9 @@
     {
         "caption": "Cdnjs: Import Entire File",
         "command": "cdnjs_file"
+    },
+    {
+        "caption": "Cdnjs: Search",
+        "command": "cdnjs_search"
     }
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,31 @@
+[
+		{
+				"caption": "Preferences",
+				"mnemonic": "n",
+				"id": "preferences",
+				"children":
+				[
+						{
+							"caption": "Package Settings",
+							"mnemonic": "P",
+							"id": "package-settings",
+							"children":
+							[
+									{
+											"caption": "Sublime-Text--cdnjs",
+											"children":
+											[
+													{
+															"command": "open_file", "args":
+															{
+																	"file": "${packages}/Sublime-Text--cdnjs/cdnjs.sublime-settings"
+															},
+															"caption": "cdnjs settings"
+													}
+											]
+									}
+							]
+						}
+				]
+		}
+]

--- a/cdnjs.py
+++ b/cdnjs.py
@@ -13,7 +13,9 @@ elif int(sublime.version()) > 3000:
 if st_version == 3:
     from .lib.api import CdnjsApiCall
     from .lib.download import CdnjsDownloadFile
+    from .lib.search import CdnjsSearchCall
 else:
+    from lib.search import CdnjsSearchCall
     from lib.api import CdnjsApiCall
     from lib.download import CdnjsDownloadFile
 
@@ -38,3 +40,7 @@ class CdnjsDownloadFileCommand(sublime_plugin.TextCommand):
     def run(self, edit, **args):
         sublime.status_message("Downloading file %s" % args["file"])
         CdnjsDownloadFile(self.view, 30, "http:"+args["file"]).start()
+
+class CdnjsSearchCommand(sublime_plugin.TextCommand):
+    def run(self, edit, **args):
+        CdnjsSearchCall(self.view, 30).start()

--- a/cdnjs.sublime-settings
+++ b/cdnjs.sublime-settings
@@ -1,0 +1,8 @@
+{
+    "cache_ttl": 600,
+    "cache_disabled": false,
+    "search": {
+        "path": "/libraries?fields=assets,description&search=",
+        "domain": "http://api.cdnjs.com"
+    },
+}

--- a/lib/search.py
+++ b/lib/search.py
@@ -1,0 +1,72 @@
+import sublime
+import json
+import threading
+from .http import get
+
+class CdnjsSearchCall(threading.Thread):
+    """
+    A command that prompts the user to enter search query text.
+    """
+
+    def __init__(self, view, timeout=10):
+        self.view = view
+        self.timeout = timeout
+        self.types = [
+            ['<script> tag','Import the script tag'],
+            ['URL','Import only the URL'],
+            ['file','Import the entire file']
+        ]
+        self.settings = sublime.load_settings("cdnjs.sublime-settings")
+        self.proxies = self.settings.get("proxies", {})
+        threading.Thread.__init__(self)
+
+    def run(self):
+        self.show_type_quickpanel()
+
+    def show_type_quickpanel(self):
+        self.view.window().show_quick_panel(self.types, self.callback)
+
+    def callback(self, index):
+        if index == -1:
+            return
+
+        self.onlyURL = False
+        self.wholeFile = False
+        if self.types[index][0] == 'file':
+            self.wholeFile = True
+        elif self.types[index][0] == 'URL':
+            self.onlyURL = True
+
+        def show_input_panel():
+            self.view.window().show_input_panel(
+                'Enter a search query',
+                '',
+                self.on_done,
+                self.on_change,
+                self.on_cancel
+                )
+        sublime.set_timeout(show_input_panel, self.timeout)
+
+    def search(self,query):
+        fullUrl = "{}{}{}".format(self.settings.get('domain', 'http://api.cdnjs.com'),
+                            self.settings.get('path',
+                                         '/libraries?'
+                                         'fields=assets,'
+                                         'description&search='),
+                            query)
+        result = get(fullUrl, self.proxies, self.timeout)
+        return json.loads(result)['results'][:-1]
+
+    def on_done(self, text):
+        self.packages = self.search(text)
+        self.view.run_command('cdnjs_library_picker', {
+            "packages": self.packages,
+            "onlyURL": self.onlyURL,
+            "wholeFile": self.wholeFile
+        })
+
+    def on_change(self,**args):
+        pass
+
+    def on_cancel(self,**args):
+        pass

--- a/picker.py
+++ b/picker.py
@@ -10,7 +10,14 @@ class CdnjsLibraryPickerCommand(sublime_plugin.TextCommand):
         sublime.set_timeout(self.show_quickpanel, 10)
 
     def get_list(self):
-        return [[x['name'], x.get('description', '')] for x in self.packages]
+        package_list = []
+        for x in self.packages:
+            if not x.get('name'):
+                x.update({'name': 'n/a'})
+            if not x.get('description'):
+                x.update({'description': 'n/a'})
+            package_list.append([x['name'], x.get('description')])
+        return package_list
 
     def show_quickpanel(self):
         self.view.window().show_quick_panel(self.get_list(), self.callback)


### PR DESCRIPTION
There is a new interface in the main menu to search for the required plugin using the API suggested in https://github.com/dafrancis/Sublime-Text--cdnjs/issues/26,  before the GET request is made to the cdnjs server. The HTTP response is much smaller which makes the plugin perform quicker.

This could replace the older interface entirely, but i'l leave that up to the community to decide. Feedback is welcome.

Also added a menu item for the plugin under Preferences -> Package Settings -> Sublime-Text--cdnjs
